### PR TITLE
Update build.gradle to fix Namespace not specified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.khizar1556.html_to_pdf_plus'
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
What went wrong:
A problem occurred configuring project ':html_to_pdf_plus'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /Users/niypoo/.pub-cache/hosted/pub.dev/html_to_pdf_plus-1.0.6/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.